### PR TITLE
chore: disable DB auto-configuration for initial setup

### DIFF
--- a/backend/src/main/resources/application.properties
+++ b/backend/src/main/resources/application.properties
@@ -1,1 +1,4 @@
 spring.application.name=backend
+
+# disable the db since we are not working on it currently
+spring.autoconfigure.exclude=org.springframework.boot.autoconfigure.jdbc.DataSourceAutoConfiguration


### PR DESCRIPTION
Since we are not working with DB at the beginning development , we disable DB auto-configuration for initial setup